### PR TITLE
Fix MessagePack analyzer warnings for internal classes

### DIFF
--- a/src/NebulaStore.Core/ObjectStore.cs
+++ b/src/NebulaStore.Core/ObjectStore.cs
@@ -120,7 +120,7 @@ public class ObjectStore : IDisposable
     }
 }
 
-[MessagePackObject]
+[MessagePackObject(AllowPrivate = true)]
 internal class RootWrapper
 {
     [Key(0)]

--- a/tests/NebulaStore.Core.Tests/ObjectStoreLazyQueryTests.cs
+++ b/tests/NebulaStore.Core.Tests/ObjectStoreLazyQueryTests.cs
@@ -39,7 +39,7 @@ public class ObjectStoreLazyQueryTests
     }
 }
 
-[MessagePackObject]
+[MessagePackObject(AllowPrivate = true)]
 internal class Order
 {
     [Key(0)]
@@ -49,7 +49,7 @@ internal class Order
     public List<Product> Items { get; set; } = new();
 }
 
-[MessagePackObject]
+[MessagePackObject(AllowPrivate = true)]
 internal class Product
 {
     [Key(0)]

--- a/tests/NebulaStore.Core.Tests/ObjectStoreTests.cs
+++ b/tests/NebulaStore.Core.Tests/ObjectStoreTests.cs
@@ -68,7 +68,7 @@ public class ObjectStoreTests : IDisposable
             File.Delete(_testFilePath);
     }
 
-    [MessagePack.MessagePackObject]
+    [MessagePack.MessagePackObject(AllowPrivate = true)]
     internal class TestData
     {
         [MessagePack.Key(0)]
@@ -78,7 +78,7 @@ public class ObjectStoreTests : IDisposable
         public int Value { get; set; }
     }
 
-    [MessagePack.MessagePackObject]
+    [MessagePack.MessagePackObject(AllowPrivate = true)]
     internal class TestContainer
     {
         [MessagePack.Key(0)]


### PR DESCRIPTION
## Summary

This PR fixes all MessagePack analyzer warnings (MsgPack015) by adding `AllowPrivate = true` to `MessagePackObject` attributes on internal classes.

## Changes Made

- **src/NebulaStore.Core/ObjectStore.cs**: Added `AllowPrivate = true` to `RootWrapper` internal class
- **tests/NebulaStore.Core.Tests/ObjectStoreLazyQueryTests.cs**: Added `AllowPrivate = true` to `Order` and `Product` internal classes
- **tests/NebulaStore.Core.Tests/ObjectStoreTests.cs**: Added `AllowPrivate = true` to `TestData` and `TestContainer` internal classes

## Problem Solved

The MessagePack analyzer was generating warnings because internal classes with `MessagePackObject` attributes need `AllowPrivate = true` to indicate that non-public types and members are allowed for serialization.

## Verification

✅ Build now completes without any warnings
✅ All 5 MsgPack015 warnings resolved
✅ No functional changes to the codebase

## References

- [MessagePack MsgPack015 Analyzer Documentation](https://github.com/MessagePack-CSharp/MessagePack-CSharp/blob/master/doc/analyzers/MsgPack015.md)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author