### PR TITLE
Convert Vietnamese comments to English

### DIFF
--- a/src/NebulaStore.Core/ObjectStore.cs
+++ b/src/NebulaStore.Core/ObjectStore.cs
@@ -56,8 +56,8 @@ public class ObjectStore : IDisposable
     }
 
     /// <summary>
-    /// Lazy, incremental query giống DB cursor.
-    /// Traverse graph on demand, yield từng object.
+    /// Lazy, incremental query similar to DB cursor.
+    /// Traverse graph on demand, yield each object.
     /// </summary>
     public IEnumerable<T> Query<T>()
     {
@@ -76,7 +76,7 @@ public class ObjectStore : IDisposable
         visited.Add(obj);
         yield return obj;
 
-        // Nếu là collection thì duyệt từng phần tử
+        // If it's a collection, traverse each element
         if (obj is System.Collections.IEnumerable enumerable && !(obj is string))
         {
             foreach (var element in enumerable)
@@ -89,7 +89,7 @@ public class ObjectStore : IDisposable
             }
         }
 
-        // Nếu có property thì duyệt tiếp
+        // If it has properties, continue traversing
         var type = obj.GetType();
         foreach (var prop in type.GetProperties())
         {
@@ -116,7 +116,7 @@ public class ObjectStore : IDisposable
 
     public void Dispose()
     {
-        // cleanup nếu cần
+        // cleanup if needed
     }
 }
 

--- a/tests/NebulaStore.Core.Tests/ObjectStoreLazyQueryTests.cs
+++ b/tests/NebulaStore.Core.Tests/ObjectStoreLazyQueryTests.cs
@@ -27,10 +27,10 @@ public class ObjectStoreLazyQueryTests
 
         using (var store = new ObjectStore(FilePath))
         {
-            var query = store.Query<Product>(); // chưa duyệt ngay
+            var query = store.Query<Product>(); // not traversed immediately
             Assert.NotNull(query);
 
-            // Khi enumerate thì mới duyệt thật sự
+            // Only traversed when enumerated
             var expensive = query.Where(p => p.Price > 100).ToList();
 
             Assert.Single(expensive);


### PR DESCRIPTION
## Summary

This PR converts all Vietnamese comments and documentation to English to improve code readability and support international collaboration.

## Changes Made

### `src/NebulaStore.Core/ObjectStore.cs`
- Updated XML documentation for the `Query<T>()` method
- Converted Vietnamese inline comments in `TraverseGraphLazy` method
- Updated disposal comment

### `tests/NebulaStore.Core.Tests/ObjectStoreLazyQueryTests.cs`
- Converted Vietnamese test comments to English

## Details

**Before:**
- "Lazy, incremental query giống DB cursor"
- "Nếu là collection thì duyệt từng phần tử"
- "chưa duyệt ngay"

**After:**
- "Lazy, incremental query similar to DB cursor"
- "If it's a collection, traverse each element"
- "not traversed immediately"

## Impact

- ✅ No functional changes to code behavior
- ✅ Improved code readability for international developers
- ✅ Better documentation consistency
- ✅ Maintains technical accuracy of comments

## Testing

No functional changes were made, so existing tests remain valid. All comments retain their original technical meaning.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author